### PR TITLE
Update README with tech stack overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,62 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Need A Tradesman
 
-## Getting Started
+Need A Tradesman is a marketplace for homeowners to connect with vetted tradespeople. Customers can post jobs and manage responses while tradespeople browse open jobs and send quotes. Real‑time messaging and notifications keep both sides in sync.
 
-First, run the development server:
+## Tech Stack
+
+- **Next.js 15 / React 19** – App Router with server and client components
+- **TypeScript** – full type safety across the codebase
+- **Tailwind CSS & shadcn/ui** – utility‑first styling and accessible UI components
+- **Prisma** – ORM for a PostgreSQL database
+- **Clerk** – authentication and user management
+- **Redis** – caching, rate limiting and foundation for real‑time features
+- **Pusher** – real‑time chat and notifications
+- **Stripe** – planned escrow and payout system
+- **ESLint** – linting with strict configuration
+
+## Features
+
+- Role‑based access for customers and tradespeople
+- Customer flow:
+  - Post new jobs and manage your listings
+  - View applications and start chats with tradespeople
+- Tradesperson flow:
+  - Browse jobs filtered by trade and location
+  - Submit applications and quotes
+  - Dashboard with quick stats and recent activity
+- Messaging system with live updates via Pusher and Redis
+- Comprehensive caching and rate limiting through Redis
+- Planned payment workflow using Stripe Connect
+
+## Development
+
+Install dependencies and run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The app will be available at [http://localhost:3000](http://localhost:3000).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### Environment Variables
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Create a `.env.local` file and provide the following keys:
 
-## Learn More
+- `DATABASE_URL` – PostgreSQL connection string
+- `CLERK_SECRET_KEY` and `CLERK_PUBLISHABLE_KEY`
+- `REDIS_URL` – Redis instance for caching and rate limiting
+- `PUSHER_APP_ID`, `PUSHER_KEY`, `PUSHER_SECRET`, `PUSHER_CLUSTER`
+- `NEXT_PUBLIC_PUSHER_KEY`, `NEXT_PUBLIC_PUSHER_CLUSTER`
+- `STRIPE_SECRET_KEY` and `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
 
-To learn more about Next.js, take a look at the following resources:
+## Scripts
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `pnpm dev` – run a development server with TurboPack
+- `pnpm build` – generate Prisma client and build Next.js
+- `pnpm start` – start the production build
+- `pnpm lint` – run ESLint across the project
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## License
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+This project is provided as‑is for demonstration purposes.


### PR DESCRIPTION
## Summary
- rewrite `README` to describe the app and its technology stack instead of the default Vercel text

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_687e980fb4f88333ada8de8cf1a46114