### PR TITLE
## ✅ Implementation Complete: Airbnb-Style Pricing UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.14",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toast": "^1.2.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-navigation-menu':
         specifier: ^1.2.14
         version: 1.2.14(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -745,6 +748,19 @@ packages:
 
   '@radix-ui/react-navigation-menu@1.2.14':
     resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3439,6 +3455,29 @@ snapshots:
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      aria-hidden: 1.2.6
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      react-remove-scroll: 2.7.1(@types/react@19.2.2)(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)

--- a/src/components/payments/DepositPaymentModal.tsx
+++ b/src/components/payments/DepositPaymentModal.tsx
@@ -12,7 +12,8 @@ import {
 } from "@/components/ui/dialog";
 import { Loader2 } from "lucide-react";
 import { createLogger } from '@/lib/logger';
-import { calculateCustomerFee, STRIPE_CONFIG } from '@/lib/stripe';
+import { calculateCustomerFee } from '@/lib/stripe';
+import { PriceBreakdownModal } from "@/components/pricing/PriceBreakdownModal";
 
 const logger = createLogger('deposit-payment-modal');
 
@@ -35,6 +36,7 @@ export function DepositPaymentModal({
 }: DepositPaymentModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
   
   // Calculate customer platform fee using centralized function
   const customerFeeInPence = calculateCustomerFee(depositAmount);
@@ -88,32 +90,27 @@ export function DepositPaymentModal({
         </DialogHeader>
 
         <div className="flex flex-col space-y-4 py-4">
-          <div className="rounded-md bg-muted p-4">
-            <h4 className="font-medium mb-2">Payment Breakdown</h4>
-            <ul className="text-sm space-y-2">
-              <li className="flex justify-between">
-                <span>Job:</span>
-                <span className="font-medium">{jobTitle}</span>
-              </li>
-              <li className="flex justify-between pt-2 mt-2 border-t">
-                <span>Deposit Amount:</span>
-                <span className="font-medium">
-                  £{depositAmount?.toFixed(2)}
-                </span>
-              </li>
-              <li className="flex justify-between text-muted-foreground">
-                <span>Platform Fee ({STRIPE_CONFIG.customerFeePercentage}%):</span>
-                <span>£{customerFee?.toFixed(2)}</span>
-              </li>
-              <li className="flex justify-between font-semibold pt-2 mt-2 border-t">
-                <span>Total Due:</span>
-                <span className="text-primary">£{totalAmount?.toFixed(2)}</span>
-              </li>
-              <li className="text-xs text-muted-foreground mt-3">
-                The deposit secures your booking and will be held in escrow
-                until job completion. The tradesperson receives the deposit minus a 4% platform fee.
-              </li>
-            </ul>
+          {/* Airbnb-style: Show total prominently */}
+          <div className="bg-primary/5 p-6 rounded-lg text-center">
+            <p className="text-sm text-muted-foreground mb-2">Total due</p>
+            <p className="text-3xl font-bold text-primary mb-2">
+              £{totalAmount?.toFixed(2)}
+            </p>
+            <button
+              onClick={() => setBreakdownOpen(true)}
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+              type="button"
+            >
+              View price breakdown
+            </button>
+          </div>
+
+          <div className="text-sm text-muted-foreground space-y-2">
+            <p className="font-medium text-foreground">Secure payment</p>
+            <p>
+              The deposit secures your booking and will be held in escrow
+              until job completion. You&apos;ll pay the remaining balance after the work is done.
+            </p>
           </div>
 
           {error && (
@@ -134,10 +131,19 @@ export function DepositPaymentModal({
                 Processing...
               </>
             ) : (
-              "Pay Deposit"
+              `Pay £${totalAmount?.toFixed(2)}`
             )}
           </Button>
         </DialogFooter>
+
+        <PriceBreakdownModal
+          isOpen={breakdownOpen}
+          onClose={() => setBreakdownOpen(false)}
+          quoteAmount={depositAmount}
+          customerFee={customerFee}
+          total={totalAmount}
+          title="Deposit Payment Breakdown"
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/payments/FinalPaymentModal.tsx
+++ b/src/components/payments/FinalPaymentModal.tsx
@@ -10,11 +10,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Card, CardContent } from "@/components/ui/card";
 import { CreditCard, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { createLogger } from '@/lib/logger';
-import { calculateCustomerFee, STRIPE_CONFIG } from '@/lib/stripe';
+import { calculateCustomerFee } from '@/lib/stripe';
+import { PriceBreakdownModal } from "@/components/pricing/PriceBreakdownModal";
 
 const logger = createLogger('final-payment-modal');
 
@@ -36,6 +36,7 @@ export function FinalPaymentModal({
   depositAmount,
 }: FinalPaymentModalProps) {
   const [loading, setLoading] = useState(false);
+  const [breakdownOpen, setBreakdownOpen] = useState(false);
 
   const remainingAmount = fullAmount - depositAmount;
   
@@ -87,42 +88,27 @@ export function FinalPaymentModal({
           </DialogDescription>
         </DialogHeader>
 
-        <Card>
-          <CardContent className="pt-6">
-            <div className="space-y-3">
-              <div className="flex justify-between text-sm">
-                <span>Total Quote:</span>
-                <span className="font-medium">£{fullAmount.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between text-sm text-muted-foreground">
-                <span>Deposit Paid:</span>
-                <span>-£{depositAmount.toFixed(2)}</span>
-              </div>
-              <hr />
-              <div className="flex justify-between text-sm">
-                <span>Remaining Balance:</span>
-                <span className="font-medium">£{remainingAmount.toFixed(2)}</span>
-              </div>
-              <div className="flex justify-between text-sm text-muted-foreground">
-                <span>Platform Fee ({STRIPE_CONFIG.customerFeePercentage}%):</span>
-                <span>£{customerFee.toFixed(2)}</span>
-              </div>
-              <hr />
-              <div className="flex justify-between text-base font-semibold">
-                <span>Total Due:</span>
-                <span className="text-primary">£{totalDue.toFixed(2)}</span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        {/* Airbnb-style: Show total prominently */}
+        <div className="bg-primary/5 p-6 rounded-lg text-center">
+          <p className="text-sm text-muted-foreground mb-2">Final payment due</p>
+          <p className="text-3xl font-bold text-primary mb-2">
+            £{totalDue.toFixed(2)}
+          </p>
+          <button
+            onClick={() => setBreakdownOpen(true)}
+            className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+            type="button"
+          >
+            View price breakdown
+          </button>
+        </div>
 
         <div className="space-y-3 text-sm text-muted-foreground">
           <div className="bg-muted p-3 rounded-md">
-            <p className="font-medium mb-1">Payment Details:</p>
+            <p className="font-medium mb-1 text-foreground">Payment Details:</p>
             <ul className="space-y-1 text-xs">
               <li>• This is the final payment for your completed job</li>
-              <li>• Includes a {STRIPE_CONFIG.customerFeePercentage}% platform fee on the remaining balance</li>
-              <li>• The tradesperson receives the balance minus a {STRIPE_CONFIG.tradespersonFeePercentage}% platform fee</li>
+              <li>• Remaining balance after your deposit</li>
               <li>• Funds will be transferred to the tradesperson upon payment</li>
               <li>• You&apos;ll receive a confirmation email after payment</li>
             </ul>
@@ -147,6 +133,15 @@ export function FinalPaymentModal({
             )}
           </Button>
         </DialogFooter>
+
+        <PriceBreakdownModal
+          isOpen={breakdownOpen}
+          onClose={() => setBreakdownOpen(false)}
+          quoteAmount={remainingAmount}
+          customerFee={customerFee}
+          total={totalDue}
+          title="Final Payment Breakdown"
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/payments/JobAcceptance.tsx
+++ b/src/components/payments/JobAcceptance.tsx
@@ -9,11 +9,11 @@ import { calculateCustomerFee } from '@/lib/stripe';
 import { calculateDepositAmount } from '@/lib/utils';
 
 interface JobAcceptanceProps {
-  readonly jobId: string;
-  readonly tradespersonId: string;
-  readonly jobTitle: string;
-  readonly quote: number;
-  readonly depositPercentage?: number;
+  jobId: string;
+  tradespersonId: string;
+  jobTitle: string;
+  quote: number;
+  depositPercentage?: number;
 }
 
 export function JobAcceptance({

--- a/src/components/payments/JobAcceptance.tsx
+++ b/src/components/payments/JobAcceptance.tsx
@@ -4,15 +4,16 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DepositPaymentModal } from "@/components/payments/DepositPaymentModal";
-import { calculateCustomerFee, STRIPE_CONFIG } from '@/lib/stripe';
+import { PriceBreakdownModal } from "@/components/pricing/PriceBreakdownModal";
+import { calculateCustomerFee } from '@/lib/stripe';
 import { calculateDepositAmount } from '@/lib/utils';
 
 interface JobAcceptanceProps {
-  jobId: string;
-  tradespersonId: string;
-  jobTitle: string;
-  quote: number;
-  depositPercentage?: number;
+  readonly jobId: string;
+  readonly tradespersonId: string;
+  readonly jobTitle: string;
+  readonly quote: number;
+  readonly depositPercentage?: number;
 }
 
 export function JobAcceptance({
@@ -23,6 +24,7 @@ export function JobAcceptance({
   depositPercentage = 50,
 }: JobAcceptanceProps) {
   const [paymentModalOpen, setPaymentModalOpen] = useState(false);
+  const [breakdownModalOpen, setBreakdownModalOpen] = useState(false);
 
   // Calculate deposit based on the configured percentage
   const depositAmount = calculateDepositAmount(quote, depositPercentage);
@@ -39,43 +41,37 @@ export function JobAcceptance({
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          <div className="bg-muted p-4 rounded-lg">
-            <h3 className="font-medium mb-2">Job Details</h3>
-            <p className="text-sm mb-2">{jobTitle}</p>
-            <div className="flex justify-between text-sm">
-              <span>Tradesperson Quote:</span>
-              <span className="font-medium">£{quote.toFixed(2)}</span>
-            </div>
-            <div className="flex justify-between text-sm mt-2 pt-2 border-t">
-              <span>Deposit ({depositPercentage}%):</span>
-              <span className="font-medium">£{depositAmount.toFixed(2)}</span>
-            </div>
-            <div className="flex justify-between text-sm text-muted-foreground">
-              <span>Platform Fee ({STRIPE_CONFIG.customerFeePercentage}%):</span>
-              <span>£{depositCustomerFee.toFixed(2)}</span>
-            </div>
-            <div className="flex justify-between text-sm font-semibold mt-2 pt-2 border-t">
-              <span>Total Due Now:</span>
-              <span className="text-primary">£{depositTotal.toFixed(2)}</span>
-            </div>
+          {/* Airbnb-style: Show total prominently */}
+          <div className="bg-primary/5 p-6 rounded-lg text-center">
+            <p className="text-sm text-muted-foreground mb-2">Total to pay now</p>
+            <p className="text-4xl font-bold text-primary mb-2">
+              £{depositTotal.toFixed(2)}
+            </p>
+            <button
+              onClick={() => setBreakdownModalOpen(true)}
+              className="text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 transition-colors"
+            >
+              View price breakdown
+            </button>
           </div>
 
-          <div className="text-sm text-muted-foreground">
-            <p>By accepting this quote, you agree to:</p>
-            <ul className="list-disc list-inside mt-2 space-y-1">
-              <li>Pay a {depositPercentage}% deposit plus {STRIPE_CONFIG.customerFeePercentage}% platform fee to secure your booking</li>
-              <li>Funds will be held securely until job completion</li>
-              <li>The remaining {100 - depositPercentage}% plus {STRIPE_CONFIG.customerFeePercentage}% platform fee will be due after job completion</li>
-              <li>The tradesperson receives the quote amount minus a {STRIPE_CONFIG.tradespersonFeePercentage}% platform fee</li>
+          <div className="text-sm text-muted-foreground space-y-2">
+            <p className="font-medium text-foreground">What happens next:</p>
+            <ul className="list-disc list-inside space-y-1">
+              <li>Pay {depositPercentage}% deposit to secure your booking</li>
+              <li>Funds are held securely until job completion</li>
+              <li>Pay the remaining {100 - depositPercentage}% after work is complete</li>
+              <li>Both payments include the service fee</li>
             </ul>
           </div>
 
           <div className="flex justify-end mt-6">
             <Button
               className="w-full sm:w-auto"
+              size="lg"
               onClick={() => setPaymentModalOpen(true)}
             >
-              Accept & Pay Deposit
+              Accept & Pay £{depositTotal.toFixed(2)}
             </Button>
           </div>
         </div>
@@ -87,6 +83,15 @@ export function JobAcceptance({
           tradespersonId={tradespersonId}
           jobTitle={jobTitle}
           depositAmount={depositAmount}
+        />
+
+        <PriceBreakdownModal
+          isOpen={breakdownModalOpen}
+          onClose={() => setBreakdownModalOpen(false)}
+          quoteAmount={depositAmount}
+          customerFee={depositCustomerFee}
+          total={depositTotal}
+          title="Deposit Payment Breakdown"
         />
       </CardContent>
     </Card>

--- a/src/components/pricing/PriceBreakdownModal.tsx
+++ b/src/components/pricing/PriceBreakdownModal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { STRIPE_CONFIG } from "@/lib/stripe";
+
+interface PriceBreakdownModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  quoteAmount: number;
+  customerFee: number;
+  total: number;
+  title?: string;
+}
+
+export function PriceBreakdownModal({
+  isOpen,
+  onClose,
+  quoteAmount,
+  customerFee,
+  total,
+  title = "Price Breakdown",
+}: PriceBreakdownModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Detailed breakdown of your payment
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-4">
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">Project cost:</span>
+            <span className="font-medium">£{quoteAmount.toFixed(2)}</span>
+          </div>
+          
+          <div className="flex justify-between text-sm">
+            <span className="text-muted-foreground">
+              Service fee ({STRIPE_CONFIG.customerFeePercentage}%):
+            </span>
+            <span className="font-medium">£{customerFee.toFixed(2)}</span>
+          </div>
+
+          <div className="border-t pt-3 mt-3">
+            <div className="flex justify-between">
+              <span className="font-semibold">Total:</span>
+              <span className="font-semibold text-lg">£{total.toFixed(2)}</span>
+            </div>
+          </div>
+
+          <div className="text-xs text-muted-foreground mt-4 pt-4 border-t">
+            <p>
+              The service fee helps us maintain the platform, provide customer support, 
+              and ensure secure payment processing.
+            </p>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/quotes/QuoteBuilder.tsx
+++ b/src/components/quotes/QuoteBuilder.tsx
@@ -15,6 +15,13 @@ import {
 import { QuoteItem } from "@/lib/schemas";
 import { TemplateModal } from "@/components/quotes/TemplateModal";
 import { createLogger } from '@/lib/logger';
+import { Info } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { STRIPE_CONFIG, calculateTradespersonPayout } from "@/lib/stripe";
 
 const logger = createLogger('quote-builder');
 
@@ -103,6 +110,10 @@ export function QuoteBuilder({
   );
 
   const depositAmount = requiresDeposit ? (total * depositPercentage) / 100 : 0;
+  
+  // Calculate what tradesperson will actually receive after platform fee
+  const tradespersonNetPayoutInPence = calculateTradespersonPayout(total);
+  const tradespersonNetPayout = tradespersonNetPayoutInPence / 100;
 
   // Handle template selection
   const handleTemplateSelection = (templateId: string) => {
@@ -193,7 +204,53 @@ export function QuoteBuilder({
       </Button>
 
       <div className="border-t pt-4 mt-4">
-        <div className="font-medium">Total: £{total.toFixed(2)}</div>
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="font-medium">Quote Total:</span>
+            <span className="text-lg font-semibold">£{total.toFixed(2)}</span>
+          </div>
+          
+          {total > 0 && (
+            <div className="bg-muted/50 p-3 rounded-lg space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">You&apos;ll receive after platform fee:</span>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                        aria-label="Fee information"
+                      >
+                        <Info className="h-4 w-4" />
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-80">
+                      <div className="space-y-2">
+                        <h4 className="font-medium text-sm">How platform fees work</h4>
+                        <p className="text-sm text-muted-foreground">
+                          We apply a <strong>{STRIPE_CONFIG.tradespersonFeePercentage}% platform fee</strong> to cover payment processing and platform costs.
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          The customer pays the quote amount plus a <strong>{STRIPE_CONFIG.customerFeePercentage}% service fee</strong>.
+                        </p>
+                        <div className="pt-2 border-t text-xs text-muted-foreground">
+                          Your quote is what the customer sees as the project cost. Set this based on your desired take-home amount.
+                        </div>
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <span className="font-semibold text-green-600 dark:text-green-400">
+                  £{tradespersonNetPayout.toFixed(2)}
+                </span>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                Platform fee ({STRIPE_CONFIG.tradespersonFeePercentage}%): £{(total - tradespersonNetPayout).toFixed(2)}
+              </div>
+            </div>
+          )}
+        </div>
 
         {onRequiresDepositChange && (
           <div className="flex items-center space-x-2 mt-4">

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }


### PR DESCRIPTION
I've successfully implemented the three key UX improvements to match Airbnb's pricing presentation:

### **1. Tradesperson Quote Builder - Live Net Calculator** ✅

**File**: QuoteBuilder.tsx

**Changes**:
- Added live calculation showing tradesperson's take-home after platform fee
- Displays: "You'll receive: £X after Y% platform fee" in real-time as they enter quote items
- Added info popover (ℹ️) explaining:
  - Platform fee percentage for tradespeople
  - Customer service fee percentage
  - How to set quotes based on desired net amount
- Shows breakdown of platform fee deduction
- Visual feedback with green highlight on net amount

**New Components Created**:
- popover.tsx - Radix UI popover component (shadcn-style)

---

### **2. Customer View - Total-First Display** ✅

**Files Updated**:
- JobAcceptance.tsx
- DepositPaymentModal.tsx
- FinalPaymentModal.tsx

**Changes**:
- **Prominent total display**: Large, bold total amount shown first
- **Hidden breakdown by default**: No upfront itemization
- **"View price breakdown" button**: Opens modal on click
- **Cleaner messaging**: Focuses on what customer pays, not fee structure
- **Consistent buttons**: Show total amount in CTA (e.g., "Pay £530.00")

---

### **3. Price Breakdown Modal** ✅

**File**: PriceBreakdownModal.tsx

**Features**:
- Shows project cost (quote amount)
- Shows service fee with percentage
- Shows total
- **Does NOT show tradesperson's fee** (Airbnb principle: customers never see host fees)
- Helpful explanation text about service fee purpose
- Clean, simple layout

---

### **Technical Details**:

**Dependencies Added**:
- `@radix-ui/react-popover@1.1.15`

**Key Functions Used**:
- `calculateTradespersonPayout()` - Computes net after platform fee
- `calculateCustomerFee()` - Computes customer service fee
- `STRIPE_CONFIG` - Centralized fee configuration

**Current Fee Structure**:
- Customer pays: Quote + 6% service fee
- Tradesperson receives: Quote - 4% platform fee
- Total platform margin: 10%

---

### **What Users See Now**:

**Tradespeople** (when creating quotes):
```
Quote Total: £1,000.00

You'll receive after platform fee:  ℹ️  £960.00
Platform fee (4%): £40.00
```

**Customers** (when accepting/paying):
```
┌─────────────────────┐
│  Total to pay now   │
│                     │
│     £1,060.00       │
│                     │
│ View price breakdown│ ← Click to see details
└─────────────────────┘
```

**In Breakdown Modal**:
```
Project cost:           £1,000.00
Service fee (6%):          £60.00
────────────────────────────────
Total:                 £1,060.00
```

---

### **Files Modified** (8 total):
1. ✅ QuoteBuilder.tsx - Live net calculator
2. ✅ popover.tsx - NEW popover component
3. ✅ PriceBreakdownModal.tsx - NEW breakdown modal
4. ✅ JobAcceptance.tsx - Airbnb-style total view
5. ✅ DepositPaymentModal.tsx - Airbnb-style total view
6. ✅ FinalPaymentModal.tsx - Airbnb-style total view

**All tests pass**: ✅ Type-check ✅ Lint

The implementation follows Airbnb's exact pattern: **customers see clean totals, tradespeople see transparent net calculations**. No fee structure changes were made - purely UX polish! 🎨